### PR TITLE
Add Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Despite its name this is not affiliated with `ndi`, `ndi-sdk`, `ndi-sys` crates
 
 ## Version compatibility
 
-This crate is currently tested against SDK version 6.2.0.3
+This crate is currently tested against SDK version 6.2.0.3 on Windows and 6.3.2.0 on Linux.
 
 The raw bindings are generated from the header files in the SDK installation
 directory, this way generated code will always match the version on the machine
@@ -39,10 +39,17 @@ it is compiled with and linked against.
 
 ## Platform Support
 
-This crates `build.rs` is currently lacking support for platforms other than
-Windows x64, because I had no time for it so far. If you are working on another
-platform, feel free to add support for it. (It shouldn't be that complicated,
-windows support is less than 30 lines of nearly-boilerplate code)
+| OS      | Architecture | Support | Notes                                                                                                    |
+| ------- | ------------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| Windows | x86_64       | ✅      | `NDI_SDK_DIR` needs to be set                                                                            |
+| Linux   | x86_64       | ✅      | `NDI_HEADER_DIR` needs to be set if headers are not in /usr/include, and LDPATH must include `libndi.so` |
+| MacOS   | x86_64       | ❌      |                                                                                                          |
+| MacOS   | AArch64      | ❌      |                                                                                                          |
+
+All platforms not mentioned are unsupported and error out during the build.
+
+Feel free to add support for other platforms supported by the NDI SDK. (It shouldn't be that complicated,
+Windows support is less than 30 lines of nearly-boilerplate code)
 
 ## Installation
 

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,19 @@ fn main() {
     }
 }
 
-#[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        // uses prebuilt stub bindings
+    } else {
+        linux();
+    }
+}
+
+#[cfg(not(all(
+    any(target_os = "windows", target_os = "linux"),
+    target_arch = "x86_64"
+)))]
 fn main() {
     if std::env::var("DOCS_RS").is_ok() {
         // uses prebuilt stub bindings
@@ -23,6 +35,7 @@ fn main() {
     }
 }
 
+#[allow(unused)]
 fn windows() {
     let ndi_sdk_dir = PathBuf::from(env::var("NDI_SDK_DIR").expect("Failed to locate the NDI SDK"));
 
@@ -47,6 +60,30 @@ fn windows() {
         Path::new(&env::var("OUT_DIR").unwrap()).join("../../../deps/Processing.NDI.Lib.x64.dll"),
     )
     .unwrap();
+}
+
+#[allow(unused)]
+fn linux() {
+    let ndi_header_file =
+        PathBuf::from(env::var("NDI_HEADER_DIR").unwrap_or("/usr/include".into()))
+            .join("Processing.NDI.Lib.h");
+    if !ndi_header_file.exists() {
+        panic!(
+            "You are missing the Processing.NDI.Lib.h header. Please install the Linux NDI SDK from https://ndi.video or through your package manager. If you have installed the SDK, but the header file is not located in /usr/include, set NDI_HEADER_DIR to point to the appropriate directory containing the header."
+        );
+    }
+
+    println!("cargo::rustc-link-lib=dylib=ndi");
+
+    let bindings = bindgen::Builder::default().header(ndi_header_file.to_str().unwrap());
+
+    generate_bindings(bindings);
+
+    // fs::copy(
+    //     ndi_sdk_dir.join("Bin/x64/Processing.NDI.Lib.x64.dll"),
+    //     Path::new(&env::var("OUT_DIR").unwrap()).join("../../../deps/Processing.NDI.Lib.x64.dll"),
+    // )
+    // .unwrap();
 }
 
 fn generate_bindings(builder: Builder) {
@@ -82,7 +119,7 @@ fn generate_bindings(builder: Builder) {
 fn stub_bindings(mut bindings: String) -> String {
     bindings = bindings.replace("\r\n", "\n");
 
-    let re = Regex::new("(?s)(?:unsafe )?extern \"C\" \\{([^}]+)\\}").unwrap();
+    let re = Regex::new(r#"(?s)(?:unsafe )?extern "C" \{([^}]+)\}"#).unwrap();
 
     let mut replacements = 0;
 
@@ -114,11 +151,22 @@ fn stub_bindings(mut bindings: String) -> String {
         "No unsafe extern \"C\" functions found in the bindings"
     );
 
-    assert_eq!(
-        bindings.matches("extern \"C\"").count(),
-        0,
-        "Found 'extern \"C\"' in the bindings, all should have been replaced"
-    );
+    // The following assertion does not work with function pointer arguments, which are present in the Linux bindings.
+    // Example snippet:
+    // ```
+    //  pub util_audio_to_interleaved_16s_v3: ::std::option::Option<
+    //     unsafe extern "C" fn(
+    //         p_src: *const NDIlib_audio_frame_v3_t,
+    //         p_dst: *mut NDIlib_audio_frame_interleaved_16s_t,
+    //     ) -> bool,
+    // >,
+    // ```
+
+    // assert_eq!(
+    //     bindings.matches("extern \"C\"").count(),
+    //     0,
+    //     "Found 'extern \"C\"' in the bindings, all should have been replaced"
+    // );
 
     format!("// Stub build\n{bindings}")
 }

--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,7 @@ fn linux() {
     }
 
     println!("cargo::rustc-link-lib=dylib=ndi");
+    println!("cargo::rerun-if-env-changed=NDI_HEADER_DIR");
 
     let bindings = bindgen::Builder::default().header(ndi_header_file.to_str().unwrap());
 

--- a/examples/05_send.rs
+++ b/examples/05_send.rs
@@ -1,8 +1,8 @@
 use std::time::Instant;
 
 use ndi_sdk_sys::{
-    four_cc::FourCCVideo, frame::video::VideoFrame, sdk, sender::NDISenderBuilder,
-    resolution::Resolution,
+    four_cc::FourCCVideo, frame::video::VideoFrame, resolution::Resolution, sdk,
+    sender::NDISenderBuilder,
 };
 
 fn main() {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -11,7 +11,8 @@ use crate::{
 /// If you can handle all color formats you should use `Fastest`
 ///
 /// C equivalent: `NDIlib_recv_color_format_e`
-#[repr(i32)]
+#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(not(target_os = "windows"), repr(u32))]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
@@ -167,7 +168,8 @@ impl NDIBandwidthMode {
 /// describes if fielding is used and which half is in the current frame
 ///
 /// C equivalent: `NDIlib_frame_format_type_e`
-#[repr(i32)]
+#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(not(target_os = "windows"), repr(u32))]
 #[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive, IntoPrimitive)]
 pub enum NDIFieldedFrameMode {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
@@ -137,6 +139,31 @@ pub enum FromFourCCError {
     UnsupportedCombination,
 }
 
+impl std::fmt::Display for FromFourCCError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FromFourCCError::UnsupportedFormat { format } => {
+                write!(f, "Unsupported video format {format:?}")
+            }
+            FromFourCCError::WrongAlphaMode {
+                format,
+                has_alpha,
+                expected_alpha,
+            } => write!(
+                f,
+                "Wrong alpha mode in {format:?}, has {}alpha but expected {}alpha",
+                if *has_alpha { "" } else { "no " },
+                if *expected_alpha { "" } else { "no " }
+            ),
+            FromFourCCError::UnsupportedCombination => {
+                f.write_str("Unsupported format combination")
+            }
+        }
+    }
+}
+
+impl Error for FromFourCCError {}
+
 /// Selects which types of frames are transmitted and which quality is used
 ///
 /// This can be beneficial for preview screens or if you only want metadata
@@ -238,3 +265,14 @@ pub enum NDIRecvError {
     /// The frame to be written to is not writable
     NotWritable,
 }
+
+impl std::fmt::Display for NDIRecvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownType => f.write_str("Unknown frame type returned from SDK"),
+            Self::NotWritable => f.write_str("Frame is not writable"),
+        }
+    }
+}
+
+impl Error for NDIRecvError {}

--- a/src/four_cc.rs
+++ b/src/four_cc.rs
@@ -9,12 +9,15 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
     bindings::{self, NDIlib_FourCC_audio_type_e, NDIlib_FourCC_video_type_e},
+    buffer_info::BufferInfo,
     enums::NDIFieldedFrameMode,
-    buffer_info::BufferInfo, resolution::Resolution, subsampling::Subsampling,
+    resolution::Resolution,
+    subsampling::Subsampling,
 };
 
 /// Possible FourCC values for video frames.
-#[repr(i32)]
+#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(not(target_os = "windows"), repr(u32))]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
@@ -91,7 +94,8 @@ pub enum BufferInfoError {
 }
 
 /// Possible FourCC values for audio frames.
-#[repr(i32)]
+#[cfg_attr(target_os = "windows", repr(i32))]
+#[cfg_attr(not(target_os = "windows"), repr(u32))]
 #[non_exhaustive]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
@@ -132,12 +136,12 @@ impl FourCC {
 
     /// Attempts to convert the FourCC to a FourCCVideo.
     pub fn as_video(&self) -> Option<FourCCVideo> {
-        FourCCVideo::from_ffi(self.code)
+        FourCCVideo::from_ffi(self.code as u32)
     }
 
     /// Attempts to convert the FourCC to a FourCCAudio.
     pub fn as_audio(&self) -> Option<FourCCAudio> {
-        FourCCAudio::from_ffi(self.code)
+        FourCCAudio::from_ffi(self.code as u32)
     }
 
     /// formats the FourCC as a string.
@@ -172,7 +176,7 @@ impl Debug for FourCC {
 impl From<FourCCVideo> for FourCC {
     fn from(value: FourCCVideo) -> Self {
         FourCC {
-            code: value.to_ffi(),
+            code: value.to_ffi() as i32,
         }
     }
 }
@@ -180,7 +184,7 @@ impl From<FourCCVideo> for FourCC {
 impl From<FourCCAudio> for FourCC {
     fn from(value: FourCCAudio) -> Self {
         FourCC {
-            code: value.to_ffi(),
+            code: value.to_ffi() as i32,
         }
     }
 }
@@ -201,7 +205,7 @@ impl TryFrom<FourCC> for FourCCVideo {
     type Error = ();
 
     fn try_from(value: FourCC) -> Result<Self, Self::Error> {
-        FourCCVideo::from_ffi(value.code).ok_or(())
+        FourCCVideo::from_ffi(value.code as u32).ok_or(())
     }
 }
 
@@ -209,7 +213,7 @@ impl TryFrom<FourCC> for FourCCAudio {
     type Error = ();
 
     fn try_from(value: FourCC) -> Result<Self, Self::Error> {
-        FourCCAudio::from_ffi(value.code).ok_or(())
+        FourCCAudio::from_ffi(value.code as u32).ok_or(())
     }
 }
 

--- a/src/four_cc.rs
+++ b/src/four_cc.rs
@@ -130,7 +130,6 @@ impl FourCCAudio {
 #[repr(transparent)]
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct FourCC {
-    // use anything with 32bit, using signed reduces the number of casts
     code: i32,
 }
 
@@ -147,12 +146,12 @@ impl FourCC {
 
     /// Attempts to convert the FourCC to a FourCCVideo.
     pub fn as_video(&self) -> Option<FourCCVideo> {
-        FourCCVideo::from_ffi(self.code as u32)
+        FourCCVideo::from_ffi(self.code as NDIlib_FourCC_video_type_e)
     }
 
     /// Attempts to convert the FourCC to a FourCCAudio.
     pub fn as_audio(&self) -> Option<FourCCAudio> {
-        FourCCAudio::from_ffi(self.code as u32)
+        FourCCAudio::from_ffi(self.code as NDIlib_FourCC_audio_type_e)
     }
 
     /// formats the FourCC as a string.
@@ -216,7 +215,7 @@ impl TryFrom<FourCC> for FourCCVideo {
     type Error = ();
 
     fn try_from(value: FourCC) -> Result<Self, Self::Error> {
-        FourCCVideo::from_ffi(value.code as u32).ok_or(())
+        FourCCVideo::from_ffi(value.code as NDIlib_FourCC_video_type_e).ok_or(())
     }
 }
 
@@ -224,7 +223,7 @@ impl TryFrom<FourCC> for FourCCAudio {
     type Error = ();
 
     fn try_from(value: FourCC) -> Result<Self, Self::Error> {
-        FourCCAudio::from_ffi(value.code as u32).ok_or(())
+        FourCCAudio::from_ffi(value.code as NDIlib_FourCC_audio_type_e).ok_or(())
     }
 }
 

--- a/src/four_cc.rs
+++ b/src/four_cc.rs
@@ -93,6 +93,17 @@ pub enum BufferInfoError {
     UnspecifiedFourCC,
 }
 
+impl std::fmt::Display for BufferInfoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedFourCC(fourcc) => write!(f, "No layout implementation for {fourcc:?}"),
+            Self::UnspecifiedFourCC => f.write_str("Video format was not specified"),
+        }
+    }
+}
+
+impl std::error::Error for BufferInfoError {}
+
 /// Possible FourCC values for audio frames.
 #[cfg_attr(target_os = "windows", repr(i32))]
 #[cfg_attr(not(target_os = "windows"), repr(u32))]

--- a/src/frame/video.rs
+++ b/src/frame/video.rs
@@ -238,7 +238,7 @@ impl VideoFrame {
     }
 
     pub fn raw_four_cc(&self) -> FourCC {
-        FourCC::from_ffi(self.raw.FourCC)
+        FourCC::from_ffi(self.raw.FourCC as i32)
     }
 
     /// Sets the FourCC format of the frame.

--- a/src/frame/video.rs
+++ b/src/frame/video.rs
@@ -1,4 +1,5 @@
 use num::ToPrimitive;
+use std::error::Error;
 use std::fmt::Debug;
 use std::{ffi::CStr, sync::Arc};
 
@@ -208,6 +209,47 @@ pub enum VideoFrameAccessError {
     BufferInfoError(BufferInfoError),
 }
 
+impl std::fmt::Display for VideoFrameAllocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyAllocated => f.write_str("Frame already allocated"),
+            Self::BufferInfoError(buffer_info_error) => {
+                write!(f, "Obtaining framebuffer info failed: {buffer_info_error}")
+            }
+        }
+    }
+}
+
+impl Error for VideoFrameAllocationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::AlreadyAllocated => None,
+            Self::BufferInfoError(buffer_info_error) => Some(buffer_info_error),
+        }
+    }
+}
+
+impl std::fmt::Display for VideoFrameAccessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BufferInfoError(buffer_info_error) => {
+                write!(f, "Obtaining framebuffer info failed: {buffer_info_error}")
+            }
+            Self::NotAllocated => f.write_str("No framebuffer is allocated"),
+            Self::Readonly => f.write_str("Framebuffer is read-only"),
+        }
+    }
+}
+
+impl Error for VideoFrameAccessError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::BufferInfoError(buffer_info_error) => Some(buffer_info_error),
+            Self::NotAllocated | Self::Readonly => None,
+        }
+    }
+}
+
 // Property accessors
 impl VideoFrame {
     /// Gets the resolution of the frame.
@@ -311,6 +353,14 @@ impl VideoFrame {
 
 #[derive(Debug, Clone)]
 pub struct AlreadyAllocatedError {}
+
+impl std::fmt::Display for AlreadyAllocatedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Framebuffer already allocated")
+    }
+}
+
+impl Error for AlreadyAllocatedError {}
 
 // Dangerous APIs
 #[cfg(feature = "dangerous_apis")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,10 @@
 //! are APIs that allow to change the resolution of a video frame while it is
 //! allocated, which may lead to out-of-bounds memory access by safe code.
 
+// Cross-platform compatibility requires us to cast i32<->u32 regularly.
+// That’s because C enums are i32 on Windows and u32 on Linux.
+#![allow(clippy::cast_sign_loss, clippy::unnecessary_cast)]
+
 mod bindings;
 
 pub mod blocking_update;

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -337,7 +337,7 @@ impl NDIReceiver {
                 Err(NDIRecvError::UnknownType)
             }
             #[cfg(not(any(debug_assertions, feature = "strict_assertions")))]
-            _ => NDIRecvType::Unknown,
+            _ => Ok(NDIRecvType::None),
         }
     }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -3,6 +3,7 @@
 //! <https://docs.ndi.video/all/developing-with-ndi/sdk/ndi-recv>
 
 use std::{
+    error::Error,
     ffi::{CStr, CString},
     fmt::Debug,
     ptr::NonNull,
@@ -131,6 +132,16 @@ impl<Source: NDISourceLike> NDIReceiverBuilder<Source> {
 pub enum NDIReceiverBuilderError {
     CreationFailed,
 }
+
+impl std::fmt::Display for NDIReceiverBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreationFailed => f.write_str("Creating NDI receiver failed"),
+        }
+    }
+}
+
+impl Error for NDIReceiverBuilderError {}
 
 #[derive(PartialEq, Eq)]
 pub(crate) struct RawReceiver {
@@ -423,6 +434,17 @@ pub enum SendMetadataError {
     /// The metadata could not be sent because the receiver is not connected
     NotConnected,
 }
+
+impl std::fmt::Display for SendMetadataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSendable(message) => write!(f, "Metadata is not readable: {message}"),
+            Self::NotConnected => f.write_str("Receiver is not connected, cannot send metadata"),
+        }
+    }
+}
+
+impl Error for SendMetadataError {}
 
 pub struct NDIWebControlInfo<'a> {
     url: &'a CStr,

--- a/src/router.rs
+++ b/src/router.rs
@@ -60,6 +60,16 @@ pub enum NDIRouterBuilderError {
     CreationFailed,
 }
 
+impl std::fmt::Display for NDIRouterBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreationFailed => f.write_str("Creating NDI router failed"),
+        }
+    }
+}
+
+impl std::error::Error for NDIRouterBuilderError {}
+
 /// NDI Router
 ///
 /// For more information see module docs

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -1,6 +1,6 @@
 //! Contains methods for the whole SDK like startup/shutdown, CPU support tests and version lookup
 
-use std::ffi::CStr;
+use std::{error::Error, ffi::CStr};
 
 use crate::bindings;
 
@@ -77,3 +77,17 @@ pub enum NDIInitError {
     UnsupportedCPU,
     GenericError,
 }
+
+impl std::fmt::Display for NDIInitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::UnsupportedCPU => f.write_str("Unsupported CPU, NDI requires SSE4.2"),
+            #[cfg(not(target_arch = "x86_64"))]
+            Self::UnsupportedCPU => f.write_str("Unsupported CPU"),
+            Self::GenericError => f.write_str("Generic NDI SDK error"),
+        }
+    }
+}
+
+impl Error for NDIInitError {}

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,6 +1,7 @@
 //! NDI Sender
 
 use std::{
+    error::Error,
     ffi::CString,
     fmt::Debug,
     ptr::NonNull,
@@ -122,6 +123,16 @@ impl NDISenderBuilder {
 pub enum NDISenderBuilderError {
     CreationFailed,
 }
+
+impl std::fmt::Display for NDISenderBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreationFailed => f.write_str("NDI Sender creation failed"),
+        }
+    }
+}
+
+impl Error for NDISenderBuilderError {}
 
 #[derive(PartialEq, Eq)]
 pub(crate) struct RawSender {
@@ -408,3 +419,13 @@ impl Drop for NDISender {
 pub enum SendFrameError {
     NotSendable(&'static str),
 }
+
+impl std::fmt::Display for SendFrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSendable(message) => write!(f, "Frame is not sendable: {message}"),
+        }
+    }
+}
+
+impl Error for SendFrameError {}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, time::Duration};
+use std::{error::Error, ffi::CString, time::Duration};
 
 pub(crate) fn duration_to_ms(dur: Duration) -> u32 {
     dur.as_millis().try_into().unwrap_or(u32::MAX)
@@ -24,4 +24,28 @@ pub enum SourceNameError {
     NulError(std::ffi::NulError),
     /// The total length of an NDI source name should be limited to 253 characters
     TooLong,
+}
+
+impl std::fmt::Display for SourceNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NulError(nul_error) => write!(
+                f,
+                "Source name contains null characters at index {}",
+                nul_error.nul_position()
+            ),
+            Self::TooLong => {
+                f.write_str("Source name is too long, a maximum of 253 bytes are supported by NDI")
+            }
+        }
+    }
+}
+
+impl Error for SourceNameError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::NulError(nul_error) => Some(nul_error),
+            Self::TooLong => None,
+        }
+    }
 }


### PR DESCRIPTION
Perfectly functional Linux support from what I can tell :3

Please test that this still works on Windows, I would be surprised if not but I don’t have a Windows machine on hand :^)

### Fix compiling in release mode

NDIRecvType::Unknown doesn’t exist. It doesn’t seem to serve any purpose except this strict assertion here, so let’s replace it with None.

### Add Linux support

All examples work excellently! Tested against NDI SDK version 6.3.2.0

Major adjustments to the existing library:
- All enums which are directly based on C enums use repr(u32) on Linux, since enums are `unsigned int` on Linux (at least bindgen assumes so) and `int` on Windows. This is not a breaking change, since the library didn’t compile on Linux beforehand, though users now cannot rely on the repr(X) attribute.
- The absence of `unsafe extern "C"` in the stub bindings is no longer enforced, since the Linux bindings contain C function pointers which are annotated as such. Since the stubs are not regenerated on docs.rs anyways, this should not break anything.

Linux build process: We assume libndi.so is in a default library path, which should be the case if the user installed the library in any reasonable way. (Otherwise, they can set LDPATH as normal.) For the headers, we assume it’s in the standard /usr/include and require setting NDI_HEADER_DIR otherwise (very friendly error message provided).

Added a neat platform support table in case someone wants to add MacOS :>